### PR TITLE
Introduce katja_echo when running integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ otp_release:
 script:
   - ./rebar3 check
 
-install:
-  - URL='https://aphyr.com/riemann/riemann_0.2.11_all.deb'; FILE=`mktemp`; DEBIAN_FRONTEND=noninteractive; wget "$URL" -qO $FILE && sudo dpkg -i $FILE; rm $FILE
 before_script:
-  - sudo service riemann start
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod +x rebar3 

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,11 @@
 ]}.
 
 {profiles, [
-            {test, [{plugins, [coveralls]}]}
+            {test, [{plugins, [coveralls]},
+                    {deps, [
+                        {katja_echo, "0.1.1"}
+                   ]}
+            ]}
            ]
 }.
 
@@ -23,6 +27,7 @@
 
 {cover_enabled, true}.
 {cover_export_enabled, true}.
+
 {coveralls_coverdata, "_build/test/cover/*.coverdata"}.
 {coveralls_service_name, "travis-ci"}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
-{"1.2.0",
+{"1.1.0",
 [{<<"gpb">>,{pkg,<<"gpb">>,<<"4.10.5">>},1},
  {<<"katja">>,
   {git,"https://github.com/katja-beam/katja",
@@ -6,7 +6,5 @@
   0}]}.
 [
 {pkg_hash,[
- {<<"gpb">>, <<"7884C1579682B9EFAF774B532AEBDE2C896CDBDF8C85695E93C66E34414A26F5">>}]},
-{pkg_hash_ext,[
- {<<"gpb">>, <<"5E58FA28F7A49D52135ED6076A926B64825EE4C2462D2CA4F66505A95B8490B0">>}]}
+ {<<"gpb">>, <<"7884C1579682B9EFAF774B532AEBDE2C896CDBDF8C85695E93C66E34414A26F5">>}]}
 ].

--- a/test/collector_SUITE.erl
+++ b/test/collector_SUITE.erl
@@ -21,6 +21,8 @@
 -export([
   all/0,
   groups/0,
+  init_per_suite/1,
+  end_per_suite/1,
   init_per_group/2,
   end_per_group/2
 ]).
@@ -53,6 +55,14 @@ groups() ->
       config_events
     ]}
   ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(katja_echo),
+    Config.
+
+
+end_per_suite(_Config) ->
+    ok.
 
 init_per_group(without_delay, Config) ->
   ok = katja_vmstats:start(),


### PR DESCRIPTION
Using https://github.com/katja-beam/katja_echo we don't need to start a real riemann server when running tests ;)